### PR TITLE
fix syntax error

### DIFF
--- a/pybgl/connector/connector.py
+++ b/pybgl/connector/connector.py
@@ -449,7 +449,7 @@ class Connector:
                     # check ZeroMQ state
                     if self.mempool_tx:
                         if int(time.time()) - self.last_zmq_msg > self.zmq_timeout and self.zmqContext:
-                            self.log.error("ZeroMQ no messages about % minutes" % self.zmq_timeout)
+                            self.log.error("ZeroMQ no messages about %s minutes" % self.zmq_timeout)
                             try:
                                 self.zeromq_task.cancel()
                                 await asyncio.wait([self.zeromq_task])


### PR DESCRIPTION
This error caused the bgl-engine (bglapiserver) container to terminate in case zeromq failed.