### PR TITLE
fix: build bundled secp256k1 before extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ class build_clib(_build_clib):
 class build_ext(_build_ext):
     def run(self):
         if self.distribution.has_c_libraries():
+            self.run_command("build_clib")
             build_clib = self.get_finalized_command("build_clib")
             self.include_dirs.append(
                 os.path.join(build_clib.build_clib, "include"),
@@ -180,6 +181,5 @@ setup(name='pybgl',
       packages=find_packages(exclude=('libsecp256k1')),
       test_suite='tests',
       zip_safe=False)
-
 
 


### PR DESCRIPTION
Summary:
- fixes editable installs by running the bundled libsecp256k1 build before extension linking
- keeps the existing build flags wiring intact after the C library has been prepared

Related bounty or issue:
- BitgesellOfficial/bitgesell#81

What changed:
- `build_ext.run()` now invokes `build_clib` before collecting libsecp256k1 include/library flags, so `pip install -e .` can build the package from a clean checkout.

Validation:
- RED before fix: `/private/tmp/pybgl-venv-20260525/bin/pip install -e .` failed with `Package 'libsecp256k1' not found` from `pkg-config`.
- GREEN after fix: `/private/tmp/pybgl-venv-20260525/bin/pip install -e .`
- GREEN after fix: `/private/tmp/pybgl-venv-20260525/bin/python tests.py` ran 6 tests successfully.
- `git diff --check`
