### PR TITLE
fix: enforce bech32 address case rules

### DIFF
--- a/pybgl/functions/address.py
+++ b/pybgl/functions/address.py
@@ -269,9 +269,11 @@ def is_address_valid(address, testnet=False):
         if sha3_256(h[:-4])[:4] != checksum:
             return False
         return True
-    elif (address[:3] == MAINNET_SEGWIT_ADDRESS_PREFIX) \
-             or (address[:4] == TESTNET_SEGWIT_ADDRESS_PREFIX):
+    elif (address.lower()[:3] == MAINNET_SEGWIT_ADDRESS_PREFIX) \
+             or (address.lower()[:4] == TESTNET_SEGWIT_ADDRESS_PREFIX):
         if len(address) not in (43, 63):
+            return False
+        if address != address.lower() and address != address.upper():
             return False
         try:
             prefix, payload = address.split('1')
@@ -280,7 +282,7 @@ def is_address_valid(address, testnet=False):
         upp = True if prefix[0].isupper() else False
         for i in payload[1:]:
             if upp:
-                if not i.isupper() or i not in base32charset_upcase:
+                if i not in base32charset_upcase:
                     return False
             else:
                 if i.isupper() or i not in base32charset:

--- a/pybgl/test/bech32_address_validation.py
+++ b/pybgl/test/bech32_address_validation.py
@@ -1,0 +1,23 @@
+import unittest
+
+from pybgl import functions
+from pybgl.functions import script as tools
+
+
+class Bech32AddressValidationTests(unittest.TestCase):
+    def test_accepts_uppercase_bech32_address(self):
+        public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        address_hash = tools.hash160(public_key)
+        address = functions.hash_to_address(address_hash)
+
+        self.assertTrue(functions.is_address_valid(address))
+        self.assertTrue(functions.is_address_valid(address.upper()))
+
+    def test_rejects_mixed_case_bech32_payload(self):
+        public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        address_hash = tools.hash160(public_key)
+        address = functions.hash_to_address(address_hash)
+        mixed_case_payload = address[:4] + address[4].upper() + address[5:]
+
+        self.assertTrue(functions.is_address_valid(address))
+        self.assertFalse(functions.is_address_valid(mixed_case_payload))

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ import pybgl
 # from pybgl.test.shamir import *
 from pybgl.test.hash_functions import *
 from pybgl.test.create_transaction import *
+from pybgl.test.bech32_address_validation import *
 # testLoad = unittest.TestLoader()
 # suites = testLoad.loadTestsFromModule(pybgl.test)
 #


### PR DESCRIPTION
Summary:
Enforce Bech32/SegWit address case rules in pybgl address validation.

Related bounty or issue:
BitgesellOfficial/bitgesell#81

What changed:
- Accepts valid all-uppercase Bech32 addresses by matching the HRP case-insensitively before validation.
- Keeps rejecting mixed-case Bech32 addresses before checksum normalization.
- Allows digits in uppercase Bech32 payloads while still checking the uppercase Bech32 charset.
- Adds regression tests for uppercase acceptance and mixed-case rejection.
- Wires the focused regression into the existing top-level tests.py runner.

Validation:
- python3 -m unittest pybgl.test.bech32_address_validation
- python3 tests.py
- git diff --check

Notes:
This is separate from pybgl#3 and does not touch packaging/build behavior.
